### PR TITLE
No longer inject push promise on non cacheable responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http.cache.spec.version>develop-SNAPSHOT</nukleus.http.cache.spec.version>
+    <nukleus.http.cache.spec.version>0.14</nukleus.http.cache.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http.cache.spec.version>0.13</nukleus.http.cache.spec.version>
+    <nukleus.http.cache.spec.version>develop-SNAPSHOT</nukleus.http.cache.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
@@ -20,6 +20,8 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Objects.requireNonNull;
 import static org.reaktivity.nukleus.buffer.BufferPool.NO_SLOT;
 import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpCacheUtils.canBeServedByCache;
+import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpCacheUtils.canInjectPushPromise;
+import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpCacheUtils.isPrivateCacheableResponse;
 import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpCacheUtils.responseCanSatisfyRequest;
 import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpHeaders.CONTENT_LENGTH;
 import static org.reaktivity.nukleus.http_cache.internal.stream.util.HttpHeaders.STATUS;
@@ -604,8 +606,9 @@ public class ProxyStreamFactory implements StreamFactory
                 final ListFW<HttpHeaderFW> responseHeaders,
                 final ListFW<HttpHeaderFW> requestHeaders)
         {
-            if (requestHeaders.anyMatch(SHOULD_POLL)
-                    && (HttpCacheUtils.canInjectPushPromise(requestHeaders)))
+            if (isPrivateCacheableResponse(responseHeaders)
+                    && requestHeaders.anyMatch(SHOULD_POLL)
+                    && canInjectPushPromise(requestHeaders))
             {
 
                 if (responseHeaders.anyMatch(h -> HttpHeaders.CACHE_CONTROL.equals(h.name().asString())))

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HttpCacheUtils.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HttpCacheUtils.java
@@ -250,12 +250,12 @@ public final class HttpCacheUtils
         {
             return false;
         }
-        return HttpCacheUtils.isPrivateCacheableResponse(responseHeaders);
+        return isPrivateCacheableResponse(responseHeaders);
     }
 
     public static boolean isPrivateCacheableResponse(ListFW<HttpHeaderFW> responseHeaders)
     {
-        String cacheControl = HttpHeadersUtil.getHeader(responseHeaders, "cache-control");
+        String cacheControl = getHeader(responseHeaders, "cache-control");
         if (cacheControl != null)
         {
             CacheControlParser parser = new  CacheControlParser(cacheControl);

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/server/ProxyCacheSyncIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/server/ProxyCacheSyncIT.java
@@ -93,6 +93,17 @@ public class ProxyCacheSyncIT
     @Test
     @Specification({
         "${route}/proxy/controller",
+        "${streams}/not.inject.push.promise.if.not.cacheable/accept/client",
+        "${streams}/not.inject.push.promise.if.not.cacheable/connect/server",
+    })
+    public void shouldNotInjectPushPromiseIfNotCacheable() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/proxy/controller",
         "${streams}/inject.header.values/accept/client",
         "${streams}/inject.header.values/connect/server",
     })


### PR DESCRIPTION
depends on https://github.com/reaktivity/nukleus-http-cache.spec/pull/18