### PR TITLE
Made K3poRule be the outer rule for the rule chains in all ITs 

### DIFF
--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
@@ -54,7 +54,7 @@ public class EdgeArchProxyIT
     private final HttpCacheCountersRule counters = new HttpCacheCountersRule(reaktor);
 
     @Rule
-    public final TestRule chain = outerRule(reaktor).around(counters).around(k3po).around(timeout);
+    public final TestRule chain = outerRule(k3po).around(reaktor).around(counters).around(timeout);
 
     @Test
     @Specification({

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
@@ -51,7 +51,7 @@ public class ProxyExceptionsIT
     private final HttpCacheCountersRule counters = new HttpCacheCountersRule(reaktor);
 
     @Rule
-    public final TestRule chain = outerRule(reaktor).around(counters).around(k3po).around(timeout);
+    public final TestRule chain = outerRule(k3po).around(reaktor).around(counters).around(timeout);
 
     @Test
     @Specification({

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsWithConfigurationIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsWithConfigurationIT.java
@@ -48,7 +48,7 @@ public class ProxyExceptionsWithConfigurationIT
             .clean();
 
     @Rule
-    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+    public final TestRule chain = outerRule(k3po).around(reaktor).around(timeout);
 
     @Ignore("ABORT vs RESET read order not yet guaranteed to match write order")
     @Test

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/Rfc7234ProxyIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/Rfc7234ProxyIT.java
@@ -52,7 +52,7 @@ public class Rfc7234ProxyIT
     private final HttpCacheCountersRule counters = new HttpCacheCountersRule(reaktor);
 
     @Rule
-    public final TestRule chain = outerRule(reaktor).around(counters).around(k3po).around(timeout);
+    public final TestRule chain = outerRule(k3po).around(reaktor).around(counters).around(timeout);
 
     @Test
     @Specification({


### PR DESCRIPTION
to avoid IllegalStateException: Missing file for streams caused by a race between ReaktorRule.clean() in one test method and k3po nukleus transport shutdown for the previously executed test.