### PR TITLE
Sends 503 retry-after for initial request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/jitsni/nukleus-http-cache.spec
-  - cd nukleus-http-cache.spec
-  - git checkout send.503.retry.after
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk9
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - rm ~/.m2/settings.xml
   - git clone https://github.com/jitsni/nukleus-http-cache.spec
   - cd nukleus-http-cache.spec
-  - git checkout 503.retry.after
+  - git checkout send.503.retry.after
   - mvn clean install -DskipTests
   - cd ..
 jdk:

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.http.cache.spec.version>develop-SNAPSHOT</nukleus.http.cache.spec.version>
+    <nukleus.http.cache.spec.version>0.44</nukleus.http.cache.spec.version>
     <reaktor.version>0.56</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Cache.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Cache.java
@@ -251,19 +251,6 @@ public class Cache
         return false;
     }
 
-    private boolean serveUpdateRequest(
-            CacheEntry entry,
-            ListFW<HttpHeaderFW> request,
-            OnUpdateRequest updateRequest)
-    {
-        if (entry.canServeUpdateRequest(request))
-        {
-            entry.serveClient(updateRequest);
-            return true;
-        }
-        return false;
-    }
-
     public void notifyUncommitted(InitialRequest request)
     {
         this.uncommittedRequests.computeIfAbsent(request.requestURLHash(), p -> new PendingCacheEntries(request));
@@ -290,9 +277,9 @@ public class Cache
         entry.purge();
     }
 
-    public void purgeOld()
+    public boolean purgeOld()
     {
-        this.cachedEntries.purgeLRU();
+        return this.cachedEntries.purgeLRU();
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Int2CacheHashMapWithLRUEviction.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Int2CacheHashMapWithLRUEviction.java
@@ -76,8 +76,17 @@ public class Int2CacheHashMapWithLRUEviction
         return result;
     }
 
-    public void purgeLRU()
+    /*
+     * @return true if entries are purged
+     *         false otherwise
+     */
+    public boolean purgeLRU()
     {
+        if (lruEntryList.size() < PURGE_SIZE)
+        {
+            return false;
+        }
+
         final List<Integer> subList = lruEntryList.subList(0, PURGE_SIZE);
         subList.forEach(i ->
         {
@@ -89,5 +98,6 @@ public class Int2CacheHashMapWithLRUEviction
         subList.clear();
 
         assert cachedEntries.size() == lruEntryList.size();
+        return true;
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheRefreshRequest.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheRefreshRequest.java
@@ -57,7 +57,7 @@ public class CacheRefreshRequest extends CacheableRequest
     }
 
     @Override
-    public boolean cache(
+    public boolean storeResponseHeaders(
         ListFW<HttpHeaderFW> responseHeaders,
         Cache cache,
         BufferPool bufferPool)
@@ -66,7 +66,7 @@ public class CacheRefreshRequest extends CacheableRequest
             ":status".equals(h.name().asString()) &&
             h.value().asString().startsWith("2")))
         {
-            boolean noError = super.cache(responseHeaders, cache, bufferPool);
+            boolean noError = super.storeResponseHeaders(responseHeaders, cache, bufferPool);
             if (!noError)
             {
                 this.purge();

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheableRequest.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheableRequest.java
@@ -104,7 +104,7 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         requestBuffer.getBytes(0, buffer, 0, requestBuffer.capacity());
     }
 
-    public boolean cache(
+    public boolean storeResponseHeaders(
             ListFW<HttpHeaderFW> responseHeaders,
             Cache cache,
             BufferPool bp)
@@ -120,7 +120,11 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         int headerSlot = bp.acquire(this.etag().hashCode());
         while (headerSlot == Slab.NO_SLOT)
         {
-            cache.purgeOld();
+            boolean purged = cache.purgeOld();
+            if (!purged)
+            {
+                return false;
+            }
             headerSlot = bp.acquire(this.etag().hashCode());
         }
         responseSlots.add(headerSlot);
@@ -132,15 +136,16 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         return true;
     }
 
-    public void cache(
+    public boolean storeResponseData(
         Cache cache,
         DataFW data,
         BufferPool cacheBufferPool)
     {
         if (state == CacheState.COMMITING)
         {
-            putResponse(cache, cacheBufferPool, data.payload());
+            return storeResponseData(cache, cacheBufferPool, data.payload());
         }
+        return false;
     }
 
     public void cache(EndFW end, Cache cache)
@@ -221,15 +226,15 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         return connect;
     }
 
-    private void putResponse(
+    private boolean storeResponseData(
         Cache cache,
         BufferPool bp,
         Flyweight data)
     {
-        this.putResponseData(cache, bp, data, 0);
+        return this.storeResponseData(cache, bp, data, 0);
     }
 
-    private void putResponseData(
+    private boolean storeResponseData(
         Cache cache,
         BufferPool bp,
         Flyweight data,
@@ -238,7 +243,7 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         responsePool = bp;
         if (data.sizeof() - written == 0)
         {
-            return;
+            return true;
         }
 
         final int slotCapacity = bp.slotCapacity();
@@ -249,10 +254,14 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
             int newSlot = bp.acquire(this.etag().hashCode());
             while (newSlot == Slab.NO_SLOT)
             {
-                cache.purgeOld();
+                boolean purged = cache.purgeOld();
+                if (!purged)
+                {
+                    return false;
+                }
                 if (this.state == CacheState.PURGED)
                 {
-                    return;
+                    return false;
                 }
                 newSlot = bp.acquire(this.etag().hashCode());
             }
@@ -267,8 +276,7 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
         buffer.putBytes(slotCapacity - slotSpaceRemaining, data.buffer(), data.offset() + written, toWrite);
         written += toWrite;
         responseSize += toWrite;
-        putResponseData(cache, bp, data, written);
-
+        return storeResponseData(cache, bp, data, written);
     }
 
     public boolean payloadEquals(

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/InitialRequest.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/InitialRequest.java
@@ -74,14 +74,17 @@ public class InitialRequest extends CacheableRequest
     }
 
     @Override
-    public boolean cache(
+    public boolean storeResponseHeaders(
             ListFW<HttpHeaderFW> responseHeaders,
             Cache cache,
             BufferPool bp)
     {
-        super.cache(responseHeaders, cache, bp);
-        cache.notifyUncommitted(this);
-        return true;
+        boolean stored = super.storeResponseHeaders(responseHeaders, cache, bp);
+        if (stored)
+        {
+            cache.notifyUncommitted(this);
+        }
+        return stored;
     }
 
     public void purge()

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
@@ -74,6 +74,7 @@ public class ProxyStreamFactory implements StreamFactory
     final LongSupplier cacheMisses;
     final LongSupplier scheduledRetries;
     final LongSupplier executedRetries;
+    final LongSupplier sentRetries;
     final Random random;
     final int retryMin;
     final int retryMax;
@@ -95,7 +96,8 @@ public class ProxyStreamFactory implements StreamFactory
         int retryMin,
         int retryMax,
         LongSupplier scheduledRetries,
-        LongSupplier executedRetries)
+        LongSupplier executedRetries,
+        LongSupplier sentRetries)
     {
         this.supplyEtag = supplyEtag;
         this.router = requireNonNull(router);
@@ -122,6 +124,7 @@ public class ProxyStreamFactory implements StreamFactory
         this.retryMax = retryMax;
         this.scheduledRetries = scheduledRetries;
         this.executedRetries = executedRetries;
+        this.sentRetries = sentRetries;
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactoryBuilder.java
@@ -57,6 +57,7 @@ public class ProxyStreamFactoryBuilder implements StreamFactoryBuilder
     private LongSupplier cacheMisses;
     private LongSupplier scheduledRetries;
     private LongSupplier executedRetries;
+    private LongSupplier sentRetries;
     private Function<String, LongSupplier> supplyCounter;
     private LongConsumer cacheEntries;
 
@@ -132,6 +133,7 @@ public class ProxyStreamFactoryBuilder implements StreamFactoryBuilder
         cacheMisses = supplyCounter.apply("cache.misses");
         scheduledRetries = supplyCounter.apply("scheduled.retries");
         executedRetries = supplyCounter.apply("executed.retries");
+        sentRetries = supplyCounter.apply("sent.retries");
         return this;
     }
 
@@ -182,6 +184,7 @@ public class ProxyStreamFactoryBuilder implements StreamFactoryBuilder
                 retryMin,
                 retryMax,
                 scheduledRetries,
-                executedRetries);
+                executedRetries,
+                sentRetries);
     }
 }


### PR DESCRIPTION
Breaks cache eviction loop when there are no entries to be evicted. After there are no more evictions possible :
- if there is no slot for initial request, send 503 + retry-after
- if there is no slot for refresh request, reschedule it for later
- if there is no slot for response headers, fall back to proxy (and the request is purged)
- if there is no slot for response data, fall back to proxy (and the request is purged)