### PR TITLE
Requests are allocated on heap

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/HttpCacheConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/HttpCacheConfiguration.java
@@ -22,8 +22,11 @@ public class HttpCacheConfiguration extends Configuration
     public static final String HTTP_CACHE_CAPACITY = "nukleus.http_cache.capacity";
     public static final String HTTP_CACHE_SLOT_CAPACITY = "nukleus.http_cache.slot.capacity";
 
+    public static final String HTTP_CACHE_MAXIMUM_REQUESTS = "nukleus.http_cache.maximum.requests";
+
     private static final int HTTP_CACHE_CAPACITY_DEFAULT = 65536 * 64;
     private static final int HTTP_CACHE_SLOT_CAPACITY_DEFAULT = 0x4000; // ALSO is max header size
+    private static final int HTTP_CACHE_MAXIMUM_REQUESTS_DEFAULT = 65536;
 
     public HttpCacheConfiguration(
         Configuration config)
@@ -39,6 +42,11 @@ public class HttpCacheConfiguration extends Configuration
     public int cacheSlotCapacity()
     {
         return getInteger(HTTP_CACHE_SLOT_CAPACITY, HTTP_CACHE_SLOT_CAPACITY_DEFAULT);
+    }
+
+    public int maximumRequests()
+    {
+        return getInteger(HTTP_CACHE_MAXIMUM_REQUESTS, HTTP_CACHE_MAXIMUM_REQUESTS_DEFAULT);
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Cache.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/Cache.java
@@ -49,8 +49,8 @@ public class Cache
     final Int2CacheHashMapWithLRUEviction cachedEntries;
     public final BufferPool cachedRequestBufferPool;
     public final BufferPool cachedResponseBufferPool;
-    public final BufferPool cachedRequest1BufferPool;
-    public final BufferPool cachedResponse1BufferPool;
+    final BufferPool cachedRequest1BufferPool;
+    final BufferPool cachedResponse1BufferPool;
 
     final BufferPool refreshBufferPool;
     final BufferPool requestBufferPool;

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/CacheEntry.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/CacheEntry.java
@@ -69,7 +69,7 @@ public final class CacheEntry
     private Instant lazyInitiatedResponseReceivedAt;
     private Instant lazyInitiatedResponseStaleAt;
 
-    final CacheableRequest cachedRequest;
+    private final CacheableRequest cachedRequest;
 
     private final List<PreferWaitIfNoneMatchRequest> subscribers = new ArrayList<>(); // TODO, lazy init
 

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/InitialRequest.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/InitialRequest.java
@@ -95,10 +95,11 @@ public class InitialRequest extends CacheableRequest
     }
 
     @Override
-    public void cache(EndFW end, Cache cache)
+    public boolean cache(EndFW end, Cache cache)
     {
-        super.cache(end, cache);
+        boolean cached = super.cache(end, cache);
         cache.servePendingInitialRequests(requestURLHash());
+        return cached;
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyAcceptStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyAcceptStream.java
@@ -205,7 +205,7 @@ final class ProxyAcceptStream
         long authorization,
         short authScope)
     {
-        boolean stored = storeRequest(requestHeaders, streamFactory.streamBufferPool);
+        boolean stored = storeRequest(requestHeaders, streamFactory.requestBufferPool);
         if (!stored)
         {
             send503RetryAfter();
@@ -223,7 +223,7 @@ final class ProxyAcceptStream
                 streamFactory.supplyCorrelationId,
                 streamFactory.supplyStreamId,
                 requestURLHash,
-                streamFactory.streamBufferPool,
+                streamFactory.requestBufferPool,
                 requestSlot,
                 streamFactory.router,
                 authorizationHeader,
@@ -290,14 +290,9 @@ final class ProxyAcceptStream
         final BufferPool bufferPool)
     {
         this.requestSlot = bufferPool.acquire(acceptStreamId);
-        while (requestSlot == NO_SLOT)
+        if (requestSlot == NO_SLOT)
         {
-            boolean purged = this.streamFactory.cache.purgeOld();
-            if (!purged)
-            {
-                return false;
-            }
-            this.requestSlot = bufferPool.acquire(acceptStreamId);
+            return false;
         }
         MutableDirectBuffer requestCacheBuffer = bufferPool.buffer(requestSlot);
         requestCacheBuffer.putBytes(0, headers.buffer(), headers.offset(), headers.sizeof());

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
@@ -95,7 +95,7 @@ public class ProxyStreamFactory implements StreamFactory
                 counters.supplyCounter.apply("initial.request.acquires"),
                 counters.supplyCounter.apply("initial.request.releases"));
         this.responseBufferPool = new CountingBufferPool(
-                requestBufferPool.duplicate(),
+                requestBufferPool,
                 counters.supplyCounter.apply("response.acquires"),
                 counters.supplyCounter.apply("response.releases"));
         this.correlations = requireNonNull(correlations);

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/ProxyStreamFactory.java
@@ -60,7 +60,7 @@ public class ProxyStreamFactory implements StreamFactory
     final BudgetManager budgetManager;
 
     final LongSupplier supplyStreamId;
-    final BufferPool streamBufferPool;
+    final BufferPool requestBufferPool;
     final BufferPool responseBufferPool;
     final Long2ObjectHashMap<Request> correlations;
     final LongObjectBiConsumer<Runnable> scheduler;
@@ -77,7 +77,7 @@ public class ProxyStreamFactory implements StreamFactory
         RouteManager router,
         BudgetManager budgetManager,
         MutableDirectBuffer writeBuffer,
-        BufferPool bufferPool,
+        BufferPool requestBufferPool,
         LongSupplier supplyStreamId,
         LongSupplier supplyCorrelationId,
         Long2ObjectHashMap<Request> correlations,
@@ -90,12 +90,12 @@ public class ProxyStreamFactory implements StreamFactory
         this.router = requireNonNull(router);
         this.budgetManager = requireNonNull(budgetManager);
         this.supplyStreamId = requireNonNull(supplyStreamId);
-        this.streamBufferPool = new CountingBufferPool(
-                bufferPool,
+        this.requestBufferPool = new CountingBufferPool(
+                requestBufferPool,
                 counters.supplyCounter.apply("initial.request.acquires"),
                 counters.supplyCounter.apply("initial.request.releases"));
         this.responseBufferPool = new CountingBufferPool(
-                bufferPool.duplicate(),
+                requestBufferPool.duplicate(),
                 counters.supplyCounter.apply("response.acquires"),
                 counters.supplyCounter.apply("response.releases"));
         this.correlations = requireNonNull(correlations);

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HeapBufferPool.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HeapBufferPool.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.reaktivity.nukleus.http_cache.internal.stream.util;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.buffer.BufferPool;
+
+import java.nio.ByteBuffer;
+
+public class HeapBufferPool implements BufferPool
+{
+    final MutableDirectBuffer[] buffers;
+    final int slotCapacity;
+
+    public HeapBufferPool(
+        int slotCount,
+        int slotCapacity)
+    {
+        buffers = new UnsafeBuffer[slotCount];
+        this.slotCapacity = slotCapacity;
+    }
+
+    HeapBufferPool(
+        MutableDirectBuffer[] buffers,
+        int slotCapacity)
+    {
+        this.buffers = buffers;
+        this.slotCapacity = slotCapacity;
+    }
+
+    @Override
+    public int slotCapacity()
+    {
+        return slotCapacity;
+    }
+
+    @Override
+    public int acquire(long streamId)
+    {
+        for(int i=0; i < buffers.length; i++)
+        {
+            if (buffers[i] == null)
+            {
+                buffers[i] = new UnsafeBuffer(new byte[slotCapacity]);
+                return i;
+            }
+        }
+
+        return NO_SLOT;
+    }
+
+    @Override
+    public MutableDirectBuffer buffer(
+        int slot)
+    {
+        assert buffers[slot] != null;
+        return buffers[slot];
+    }
+
+    @Override
+    public ByteBuffer byteBuffer(
+        int slot)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MutableDirectBuffer buffer(
+        int slot,
+        int offset)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void release(int slot)
+    {
+        if (slot != NO_SLOT)
+        {
+            buffers[slot] = null;
+        }
+    }
+
+    @Override
+    public BufferPool duplicate()
+    {
+        return new HeapBufferPool(buffers, slotCapacity);
+    }
+
+    @Override
+    public int acquiredSlots()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HeapBufferPool.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/stream/util/HeapBufferPool.java
@@ -99,7 +99,7 @@ public class HeapBufferPool implements BufferPool
     @Override
     public BufferPool duplicate()
     {
-        return new HeapBufferPool(buffers, slotCapacity);
+        return this;
     }
 
     @Override

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
@@ -17,6 +17,7 @@ package org.reaktivity.nukleus.http_cache.internal.streams.proxy;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
+import static org.reaktivity.nukleus.http_cache.internal.HttpCacheConfiguration.HTTP_CACHE_MAXIMUM_REQUESTS;
 
 import java.time.Instant;
 
@@ -197,7 +198,7 @@ public class EdgeArchProxyIT
         k3po.finish();
         Instant finish = Instant.now();
         Assert.assertTrue(start.plusMillis(4900).isBefore(finish));
-        counters.assertExpectedCacheEntries(1, 1);
+        counters.assertExpectedCacheEntries(1, 2);
     }
 
     @Test
@@ -209,7 +210,7 @@ public class EdgeArchProxyIT
     public void shouldUpdateOnUpdateRequestsWhenPollCompletes() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1);
+        counters.assertExpectedCacheEntries(1, 2);
     }
 
     @Test
@@ -221,7 +222,7 @@ public class EdgeArchProxyIT
     public void shouldAttachToNextCacheEntryIfPushPromiseArrivesBeforeResponseCompletes() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1);
+        counters.assertExpectedCacheEntries(1, 2);
     }
 
     @Test
@@ -319,7 +320,7 @@ public class EdgeArchProxyIT
     public void shouldMaintainPollingForMultipleAuthScopes() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(2, 0, 2);
+        counters.assertExpectedCacheEntries(2, 2, 2);
     }
 
 
@@ -332,7 +333,7 @@ public class EdgeArchProxyIT
     public void noAuthorizationSendsCacheControlPrivate() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1, 0);
+        counters.assertExpectedCacheEntries(1, 2, 0);
     }
 
     @Test
@@ -344,7 +345,7 @@ public class EdgeArchProxyIT
     public void noAuthorizationSendsCacheControlPrivateExceptWhenPublic() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1, 0);
+        counters.assertExpectedCacheEntries(1, 2, 0);
     }
 
     @Test
@@ -356,7 +357,7 @@ public class EdgeArchProxyIT
     public void pollingVaryHeaderMismatch() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1, 0);
+        counters.assertExpectedCacheEntries(1, 2, 0);
     }
 
     @Test
@@ -368,7 +369,7 @@ public class EdgeArchProxyIT
     public void pollingVaryHeaderAsterisk() throws Exception
     {
         k3po.finish();
-        counters.assertExpectedCacheEntries(1, 1, 0);
+        counters.assertExpectedCacheEntries(1, 2, 0);
     }
 
     @Test
@@ -381,14 +382,14 @@ public class EdgeArchProxyIT
     {
         k3po.finish();
         Thread.sleep(100); // Wait for response to be processed
-        counters.assertExpectedCacheEntries(1, 0, 0);
+        counters.assertExpectedCacheEntries(1, 1, 0);
     }
 
     // First response gets proxied (but doesn't get stored in cache
     // as there is no buffer slot for headers)
     // Second request gets 503 + retry-after
     @Test
-    @Configure(name="nukleus.http_cache.capacity", value="16384")       // 1 buffer slot
+    @Configure(name=HTTP_CACHE_MAXIMUM_REQUESTS, value="1")       // 1 buffer slot
     @Specification({
         "${route}/proxy/controller",
         "${streams}/cache.sends.503.retry-after/accept/client",

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
@@ -123,6 +123,7 @@ public class ProxyExceptionsIT
     public void shouldAcceptReplySentResetCachebleResponse() throws Exception
     {
         k3po.finish();
+        Thread.sleep(100);
         counters.assertExpectedCacheEntries(1);
     }
 

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/ProxyExceptionsIT.java
@@ -74,7 +74,7 @@ public class ProxyExceptionsIT
     public void shouldHandleAbortSentOnCacheableRequest() throws Exception
     {
         k3po.finish();
-        assertEquals(1, counters.slabAquires() - counters.slabReleases());
+        assertEquals(1, counters.requestsCachable());
         // We proceed with request out back anyways, TODO, consider adding to test response returning and getting cached
     }
 

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/test/HttpCacheCountersRule.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/test/HttpCacheCountersRule.java
@@ -51,8 +51,8 @@ public class HttpCacheCountersRule implements TestRule
 
     public long slabAquires()
     {
-        return controller().count("initial.request.acquires") +
-                controller().count("refresh.request.acquires") +
+        return controller().count("cached.request.acquires") +
+                controller().count("cached.request.acquires") +
                 controller().count("response.acquires");
     }
 
@@ -103,6 +103,42 @@ public class HttpCacheCountersRule implements TestRule
         return controller().count("promises.canceled");
     }
 
+    public long cacheEntries()
+    {
+        return controller().count("cache.entries");
+    }
+
+    public long refreshRequests()
+    {
+        return controller().count("refresh.request.acquires");
+    }
+
+    public long cachedRequestAcquires()
+    {
+        return controller().count("cached.request.acquires");
+    }
+
+    public long cachedRequestReleases()
+    {
+        return controller().count("cached.request.releases");
+    }
+
+    public long cachedResponseAcquires()
+    {
+        return controller().count("cached.response.acquires");
+    }
+
+    public long cachedResponseReleases()
+    {
+        return controller().count("cached.response.releases");
+    }
+
+    public long cacheSlots()
+    {
+        return cachedRequestAcquires() + cachedResponseAcquires() - cachedRequestReleases() - cachedResponseReleases();
+    }
+
+
     private HttpCacheController controller()
     {
         return reaktor.controller(HttpCacheController.class);
@@ -111,14 +147,22 @@ public class HttpCacheCountersRule implements TestRule
     public void assertExpectedCacheEntries(
         int numberOfResponses)
     {
-        assertEquals(NUM_OF_SLOTS_PER_CACHE_ENTRY * numberOfResponses, slabAquires() - slabReleases());
+        assertEquals(numberOfResponses, cacheEntries());
+        assertEquals(NUM_OF_SLOTS_PER_CACHE_ENTRY * numberOfResponses, cacheSlots());
+    }
+
+    public void assertExpectedCacheRefreshes(
+        int cacheInitiatedRefreshes)
+    {
+        assertEquals(cacheInitiatedRefreshes, refreshRequests());
     }
 
     public void assertExpectedCacheEntries(
         int numberOfResponses,
         int cacheInitiatedRefreshes)
     {
-        assertEquals(NUM_OF_SLOTS_PER_CACHE_ENTRY * numberOfResponses + cacheInitiatedRefreshes, slabAquires() - slabReleases());
+        assertExpectedCacheEntries(numberOfResponses);
+        assertExpectedCacheRefreshes(cacheInitiatedRefreshes);
     }
 
     public void assertExpectedCacheEntries(
@@ -126,9 +170,8 @@ public class HttpCacheCountersRule implements TestRule
         int cacheInitiatedRefreshes,
         int requestPendingCacheUpdate)
     {
-        assertEquals(
-            NUM_OF_SLOTS_PER_CACHE_ENTRY * numberOfResponses + cacheInitiatedRefreshes + requestPendingCacheUpdate,
-            slabAquires() - slabReleases());
+        assertExpectedCacheEntries(numberOfResponses);
+        assertExpectedCacheRefreshes(cacheInitiatedRefreshes);
     }
 
     public void assertRequests(

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/test/HttpCacheCountersRule.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/test/HttpCacheCountersRule.java
@@ -49,20 +49,6 @@ public class HttpCacheCountersRule implements TestRule
         };
     }
 
-    public long slabAquires()
-    {
-        return controller().count("cached.request.acquires") +
-                controller().count("cached.request.acquires") +
-                controller().count("response.acquires");
-    }
-
-    public long slabReleases()
-    {
-        return controller().count("initial.request.releases") +
-                controller().count("refresh.request.releases") +
-                controller().count("response.releases");
-    }
-
     public long requests()
     {
         return controller().count("requests");


### PR DESCRIPTION
Cache's buffer pool is not used for requests and requests are allocated on heap.
If requests run out of space, they don't delete any entries from cache.
When a request is moved to cache, its data is copied to cache buffer pool