### PR TITLE
request state is fixed when it cannot be copied to cache as it is full.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.http.cache.spec.version>develop-SNAPSHOT</nukleus.http.cache.spec.version>
+    <nukleus.http.cache.spec.version>0.56</nukleus.http.cache.spec.version>
     <reaktor.version>0.73</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.http.cache.spec.version>0.55</nukleus.http.cache.spec.version>
+    <nukleus.http.cache.spec.version>develop-SNAPSHOT</nukleus.http.cache.spec.version>
     <reaktor.version>0.73</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheableRequest.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/request/CacheableRequest.java
@@ -154,10 +154,10 @@ public abstract class CacheableRequest extends AnswerableByCacheRequest
     {
         if (state == CacheState.COMMITING)
         {
-            state = CacheState.COMMITTED;
             boolean copied = moveDataToCachePools(cache.cachedRequestBufferPool, cache.cachedResponseBufferPool);
             if (copied)
             {
+                state = CacheState.COMMITTED;
                 cache.put(requestURLHash(), this);
             }
             else

--- a/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http_cache/internal/streams/proxy/EdgeArchProxyIT.java
@@ -440,4 +440,22 @@ public class EdgeArchProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configure(name="nukleus.http_cache.capacity", value="8192")       // 4 buffer slots
+    @Configure(name="nukleus.http_cache.slot.capacity", value="2048")
+    @Specification({
+        "${route}/proxy/controller",
+        "${streams}/polling.updates.after.cache.full/accept/client",
+        "${streams}/polling.updates.after.cache.full/connect/server",
+    })
+    public void pollingAfterCacheFull() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CACHE_UPDATE_SENT");
+        Thread.sleep(1000);
+        k3po.notifyBarrier("CACHE_UPDATE_RECEIVED");
+        k3po.finish();
+        Thread.sleep(1000);
+        counters.assertExpectedCacheEntries(1);    }
 }


### PR DESCRIPTION
CacheRefreshRequest#purge gets called. When the request is not in COMMITTED state, the corresponding cache entry is removed. So setting request to COMMITTED state when the response can be copied to cache pools.