### PR TITLE
Remove CAN_REFRESH state from checking the cache validity 

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/CacheEntry.java
+++ b/src/main/java/org/reaktivity/nukleus/http_cache/internal/proxy/cache/CacheEntry.java
@@ -639,7 +639,7 @@ public final class CacheEntry
         final boolean doesNotVaryBy = doesNotVaryBy(request);
         final boolean satisfiesFreshnessRequirements = satisfiesFreshnessRequirementsOf(request, now);
         final boolean satisfiesStalenessRequirements = satisfiesStalenessRequirementsOf(request, now)
-                || this.state == CAN_REFRESH || this.state == REFRESHING;
+                || this.state == REFRESHING;
         final boolean satisfiesAgeRequirements = satisfiesAgeRequirementsOf(request, now);
         return canBeServedToAuthorized &&
                 doesNotVaryBy &&


### PR DESCRIPTION
Remove CAN_REFRESH state from checking the cache validity since it means that we didn't schedule for cache refresh and entry couldn't be stale already.